### PR TITLE
feat: added client-id information on getClusterNodes

### DIFF
--- a/rpc-client-api/src/config.rs
+++ b/rpc-client-api/src/config.rs
@@ -352,3 +352,9 @@ pub struct RpcContextConfig {
     pub commitment: Option<CommitmentConfig>,
     pub min_context_slot: Option<Slot>,
 }
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcRecentPrioritizationFeesConfig {
+    pub percentile: Option<u16>,
+}

--- a/rpc-client-api/src/config.rs
+++ b/rpc-client-api/src/config.rs
@@ -358,3 +358,12 @@ pub struct RpcContextConfig {
 pub struct RpcRecentPrioritizationFeesConfig {
     pub percentile: Option<u16>,
 }
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcLatestBlockhashConfig {
+    #[serde(flatten)]
+    pub context: RpcContextConfig,
+    #[serde(default)]
+    pub rollback: usize,
+}

--- a/rpc-client-api/src/config.rs
+++ b/rpc-client-api/src/config.rs
@@ -17,6 +17,8 @@ pub struct RpcSignatureStatusConfig {
 pub struct RpcSendTransactionConfig {
     #[serde(default)]
     pub skip_preflight: bool,
+    #[serde(default)]
+    pub skip_sanitize: bool,
     pub preflight_commitment: Option<CommitmentLevel>,
     pub encoding: Option<UiTransactionEncoding>,
     pub max_retries: Option<usize>,

--- a/rpc-client-api/src/config.rs
+++ b/rpc-client-api/src/config.rs
@@ -23,6 +23,16 @@ pub struct RpcSendTransactionConfig {
     pub min_context_slot: Option<Slot>,
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RcpSanitizeTransactionConfig {
+    pub sig_verify: bool,
+    #[serde(flatten)]
+    pub commitment: Option<CommitmentConfig>,
+    pub encoding: Option<UiTransactionEncoding>,
+    pub min_context_slot: Option<Slot>,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcSimulateTransactionAccountsConfig {

--- a/rpc-client-api/src/filter.rs
+++ b/rpc-client-api/src/filter.rs
@@ -17,6 +17,7 @@ pub enum RpcFilterType {
     DataSize(u64),
     Memcmp(Memcmp),
     TokenAccountState,
+    ValueCmp(ValueCmp),
 }
 
 impl RpcFilterType {
@@ -57,6 +58,7 @@ impl RpcFilterType {
                 }
             }
             RpcFilterType::TokenAccountState => Ok(()),
+            RpcFilterType::ValueCmp(_) => Ok(()),
         }
     }
 
@@ -69,6 +71,9 @@ impl RpcFilterType {
             RpcFilterType::DataSize(size) => account.data().len() as u64 == *size,
             RpcFilterType::Memcmp(compare) => compare.bytes_match(account.data()),
             RpcFilterType::TokenAccountState => Account::valid_account_data(account.data()),
+            RpcFilterType::ValueCmp(compare) => {
+                compare.values_match(account.data()).unwrap_or(false)
+            }
         }
     }
 }
@@ -81,6 +86,8 @@ pub enum RpcFilterError {
     Base58DecodeError(#[from] bs58::decode::Error),
     #[error("base64 decode error")]
     Base64DecodeError(#[from] base64::DecodeError),
+    #[error("invalid ValueCmp filter")]
+    InvalidValueCmp,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
@@ -218,6 +225,178 @@ impl Memcmp {
             Some(bytes)
         } else {
             None
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ValueCmp {
+    pub left: Operand,
+    comparator: Comparator,
+    pub right: Operand,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Operand {
+    Mem {
+        offset: usize,
+        value_type: ValueType,
+    },
+    Constant(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ValueType {
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+}
+
+enum WrappedValueType {
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    U128(u128),
+}
+
+impl ValueCmp {
+    fn parse_mem_into_value_type(
+        o: &Operand,
+        data: &[u8],
+    ) -> Result<WrappedValueType, RpcFilterError> {
+        match o {
+            Operand::Mem { offset, value_type } => match value_type {
+                ValueType::U8 => {
+                    if *offset >= data.len() {
+                        return Err(RpcFilterError::InvalidValueCmp);
+                    }
+
+                    Ok(WrappedValueType::U8(data[*offset]))
+                }
+                ValueType::U16 => {
+                    if *offset + 1 >= data.len() {
+                        return Err(RpcFilterError::InvalidValueCmp);
+                    }
+                    Ok(WrappedValueType::U16(u16::from_le_bytes(
+                        data[*offset..*offset + 2].try_into().unwrap(),
+                    )))
+                }
+                ValueType::U32 => {
+                    if *offset + 3 >= data.len() {
+                        return Err(RpcFilterError::InvalidValueCmp);
+                    }
+                    Ok(WrappedValueType::U32(u32::from_le_bytes(
+                        data[*offset..*offset + 4].try_into().unwrap(),
+                    )))
+                }
+                ValueType::U64 => {
+                    if *offset + 7 >= data.len() {
+                        return Err(RpcFilterError::InvalidValueCmp);
+                    }
+                    Ok(WrappedValueType::U64(u64::from_le_bytes(
+                        data[*offset..*offset + 8].try_into().unwrap(),
+                    )))
+                }
+                ValueType::U128 => {
+                    if *offset + 15 >= data.len() {
+                        return Err(RpcFilterError::InvalidValueCmp);
+                    }
+                    Ok(WrappedValueType::U128(u128::from_le_bytes(
+                        data[*offset..*offset + 16].try_into().unwrap(),
+                    )))
+                }
+            },
+            _ => Err(RpcFilterError::InvalidValueCmp),
+        }
+    }
+
+    pub fn values_match(&self, data: &[u8]) -> Result<bool, RpcFilterError> {
+        match (&self.left, &self.right) {
+            (left @ Operand::Mem { .. }, right @ Operand::Mem { .. }) => {
+                let left = Self::parse_mem_into_value_type(left, data)?;
+                let right = Self::parse_mem_into_value_type(right, data)?;
+
+                match (left, right) {
+                    (WrappedValueType::U8(left), WrappedValueType::U8(right)) => {
+                        Ok(self.comparator.compare(left, right))
+                    }
+                    (WrappedValueType::U16(left), WrappedValueType::U16(right)) => {
+                        Ok(self.comparator.compare(left, right))
+                    }
+                    (WrappedValueType::U32(left), WrappedValueType::U32(right)) => {
+                        Ok(self.comparator.compare(left, right))
+                    }
+                    (WrappedValueType::U64(left), WrappedValueType::U64(right)) => {
+                        Ok(self.comparator.compare(left, right))
+                    }
+                    (WrappedValueType::U128(left), WrappedValueType::U128(right)) => {
+                        Ok(self.comparator.compare(left, right))
+                    }
+                    _ => Err(RpcFilterError::InvalidValueCmp),
+                }
+            }
+            (left @ Operand::Mem { .. }, Operand::Constant(constant)) => {
+                match Self::parse_mem_into_value_type(left, data)? {
+                    WrappedValueType::U8(left) => {
+                        let right = constant
+                            .parse::<u8>()
+                            .map_err(|_| RpcFilterError::InvalidValueCmp)?;
+                        Ok(self.comparator.compare(left, right))
+                    }
+                    WrappedValueType::U16(left) => {
+                        let right = constant
+                            .parse::<u16>()
+                            .map_err(|_| RpcFilterError::InvalidValueCmp)?;
+                        Ok(self.comparator.compare(left, right))
+                    }
+                    WrappedValueType::U32(left) => {
+                        let right = constant
+                            .parse::<u32>()
+                            .map_err(|_| RpcFilterError::InvalidValueCmp)?;
+                        Ok(self.comparator.compare(left, right))
+                    }
+                    WrappedValueType::U64(left) => {
+                        let right = constant
+                            .parse::<u64>()
+                            .map_err(|_| RpcFilterError::InvalidValueCmp)?;
+                        Ok(self.comparator.compare(left, right))
+                    }
+                    WrappedValueType::U128(left) => {
+                        let right = constant
+                            .parse::<u128>()
+                            .map_err(|_| RpcFilterError::InvalidValueCmp)?;
+                        Ok(self.comparator.compare(left, right))
+                    }
+                }
+            }
+            _ => Err(RpcFilterError::InvalidValueCmp),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Comparator {
+    Eq = 0,
+    Ne,
+    Gt,
+    Ge,
+    Lt,
+    Le,
+}
+
+impl Comparator {
+    // write a generic function to compare two values
+    pub fn compare<T: PartialOrd>(&self, left: T, right: T) -> bool {
+        match self {
+            Comparator::Eq => left == right,
+            Comparator::Ne => left != right,
+            Comparator::Gt => left > right,
+            Comparator::Ge => left >= right,
+            Comparator::Lt => left < right,
+            Comparator::Le => left <= right,
         }
     }
 }
@@ -454,5 +633,57 @@ mod tests {
             serialized_json,
             serde_json::from_str::<Value>(BYTES_FILTER_WITH_ENCODING).unwrap()
         );
+    }
+
+    #[test]
+    fn test_values_match() {
+        // test all the ValueCmp cases
+        let data = vec![1, 2, 3, 4, 5];
+
+        let filter = ValueCmp {
+            left: Operand::Mem {
+                offset: 1,
+                value_type: ValueType::U8,
+            },
+            comparator: Comparator::Eq,
+            right: Operand::Constant("2".to_string()),
+        };
+
+        assert!(ValueCmp {
+            left: Operand::Mem {
+                offset: 1,
+                value_type: ValueType::U8
+            },
+            comparator: Comparator::Eq,
+            right: Operand::Constant("2".to_string())
+        }
+        .values_match(&data)
+        .unwrap());
+
+        assert!(ValueCmp {
+            left: Operand::Mem {
+                offset: 1,
+                value_type: ValueType::U8
+            },
+            comparator: Comparator::Lt,
+            right: Operand::Constant("3".to_string())
+        }
+        .values_match(&data)
+        .unwrap());
+
+        assert!(ValueCmp {
+            left: Operand::Mem {
+                offset: 0,
+                value_type: ValueType::U32
+            },
+            comparator: Comparator::Eq,
+            right: Operand::Constant("67305985".to_string())
+        }
+        .values_match(&data)
+        .unwrap());
+
+        // serialize
+        let s = serde_json::to_string(&filter).unwrap();
+        println!("{}", s);
     }
 }

--- a/rpc-client-api/src/request.rs
+++ b/rpc-client-api/src/request.rs
@@ -66,6 +66,7 @@ pub enum RpcRequest {
     RegisterNode,
     RequestAirdrop,
     SendTransaction,
+    SanitizeTransaction,
     SimulateTransaction,
     SignVote,
 }
@@ -131,6 +132,7 @@ impl fmt::Display for RpcRequest {
             RpcRequest::RegisterNode => "registerNode",
             RpcRequest::RequestAirdrop => "requestAirdrop",
             RpcRequest::SendTransaction => "sendTransaction",
+            RpcRequest::SanitizeTransaction => "sanitizeTransaction",
             RpcRequest::SimulateTransaction => "simulateTransaction",
             RpcRequest::SignVote => "signVote",
         };

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -4565,6 +4565,27 @@ impl RpcClient {
         Ok(blockhash)
     }
 
+    pub async fn get_latest_blockhash_with_config(
+        &self,
+        config: RpcLatestBlockhashConfig,
+    ) -> ClientResult<(Hash, u64)> {
+        let RpcBlockhash {
+            blockhash,
+            last_valid_block_height,
+        } = self
+            .send::<Response<RpcBlockhash>>(RpcRequest::GetLatestBlockhash, json!([config]))
+            .await?
+            .value;
+        let blockhash = blockhash.parse().map_err(|_| {
+            ClientError::new_with_request(
+                RpcError::ParseError("Hash".to_string()).into(),
+                RpcRequest::GetLatestBlockhash,
+            )
+        })?;
+        Ok((blockhash, last_valid_block_height))
+    }
+
+    #[allow(deprecated)]
     pub async fn get_latest_blockhash_with_commitment(
         &self,
         commitment: CommitmentConfig,

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -1143,6 +1143,26 @@ impl RpcClient {
         }
     }
 
+    pub async fn sanitize_transaction(
+        &self,
+        transaction: &impl SerializableTransaction,
+        config: RcpSanitizeTransactionConfig,
+    ) -> ClientResult<()> {
+        let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Base64);
+        let commitment = config.commitment.unwrap_or_default();
+        let config = RcpSanitizeTransactionConfig {
+            encoding: Some(encoding),
+            commitment: Some(commitment),
+            ..config
+        };
+        let serialized_encoded = serialize_and_encode(transaction, encoding)?;
+        self.send(
+            RpcRequest::SanitizeTransaction,
+            json!([serialized_encoded, config]),
+        )
+        .await
+    }
+
     /// Simulates sending a transaction.
     ///
     /// If the transaction fails, then the [`err`] field of the returned

--- a/rpc/src/filter.rs
+++ b/rpc/src/filter.rs
@@ -9,5 +9,6 @@ pub fn filter_allows(filter: &RpcFilterType, account: &AccountSharedData) -> boo
         RpcFilterType::DataSize(size) => account.data().len() as u64 == *size,
         RpcFilterType::Memcmp(compare) => compare.bytes_match(account.data()),
         RpcFilterType::TokenAccountState => Account::valid_account_data(account.data()),
+        RpcFilterType::ValueCmp(compare) => compare.values_match(account.data()).unwrap_or(false),
     }
 }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2365,9 +2365,7 @@ impl JsonRpcRequestProcessor {
     ) -> Result<RpcResponse<RpcBlockhash>> {
         let mut bank = self.get_bank_with_config(config.context)?;
         if config.rollback > MAX_PROCESSING_AGE {
-            return Err(Error::invalid_params(format!(
-                "rollback exceeds ${MAX_PROCESSING_AGE}"
-            )));
+            return Err(Error::invalid_params(format!("rollback exceeds ${MAX_PROCESSING_AGE}")));
         }
         if config.rollback > 0 {
             let r_bank_forks = self.bank_forks.read().unwrap();
@@ -3734,7 +3732,7 @@ pub mod rpc_full {
                         {
                             (Some(format!("{:?}", version)), Some(version.feature_set))
                             // version will be displayed:
-                            // solana 2.2.15 (src:7aff93a2; feat:798020478, client:Agave)
+                            // 2.2.15 (src:7aff93a2; feat:798020478, client:Agave)
                         } else {
                             (None, None)
                         };

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2394,10 +2394,18 @@ impl JsonRpcRequestProcessor {
     fn get_recent_prioritization_fees(
         &self,
         pubkeys: Vec<Pubkey>,
+        percentile: Option<u16>,
     ) -> Result<Vec<RpcPrioritizationFee>> {
-        Ok(self
-            .prioritization_fee_cache
-            .get_prioritization_fees(&pubkeys)
+        let cache = match percentile {
+            Some(percentile) => self
+                .prioritization_fee_cache
+                .get_prioritization_fees2(&pubkeys, percentile),
+            None => self
+                .prioritization_fee_cache
+                .get_prioritization_fees(&pubkeys),
+        };
+
+        Ok(cache
             .into_iter()
             .map(|(slot, prioritization_fee)| RpcPrioritizationFee {
                 slot,
@@ -3647,6 +3655,7 @@ pub mod rpc_full {
             &self,
             meta: Self::Metadata,
             pubkey_strs: Option<Vec<String>>,
+            config: Option<RpcRecentPrioritizationFeesConfig>,
         ) -> Result<Vec<RpcPrioritizationFee>>;
     }
 
@@ -4340,6 +4349,7 @@ pub mod rpc_full {
             &self,
             meta: Self::Metadata,
             pubkey_strs: Option<Vec<String>>,
+            config: Option<RpcRecentPrioritizationFeesConfig>,
         ) -> Result<Vec<RpcPrioritizationFee>> {
             let pubkey_strs = pubkey_strs.unwrap_or_default();
             debug!(
@@ -4355,7 +4365,17 @@ pub mod rpc_full {
                 .into_iter()
                 .map(|pubkey_str| verify_pubkey(&pubkey_str))
                 .collect::<Result<Vec<_>>>()?;
-            meta.get_recent_prioritization_fees(pubkeys)
+
+            let RpcRecentPrioritizationFeesConfig { percentile } = config.unwrap_or_default();
+            if let Some(percentile) = percentile {
+                if percentile > 10_000 {
+                    return Err(Error::invalid_params(
+                        "Percentile is too big; max value is 10000".to_owned(),
+                    ));
+                }
+            }
+
+            meta.get_recent_prioritization_fees(pubkeys, percentile)
         }
     }
 }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3541,6 +3541,14 @@ pub mod rpc_full {
             config: Option<RpcSendTransactionConfig>,
         ) -> Result<String>;
 
+        #[rpc(meta, name = "sanitizeTransaction")]
+        fn sanitize_transaction(
+            &self,
+            meta: Self::Metadata,
+            data: String,
+            config: Option<RcpSanitizeTransactionConfig>,
+        ) -> Result<()>;
+
         #[rpc(meta, name = "simulateTransaction")]
         fn simulate_transaction(
             &self,
@@ -3951,6 +3959,40 @@ pub mod rpc_full {
                 durable_nonce_info,
                 max_retries,
             )
+        }
+
+        fn sanitize_transaction(
+            &self,
+            meta: Self::Metadata,
+            data: String,
+            config: Option<RcpSanitizeTransactionConfig>,
+        ) -> Result<()> {
+            let RcpSanitizeTransactionConfig {
+                sig_verify,
+                commitment,
+                encoding,
+                min_context_slot,
+            } = config.unwrap_or_default();
+            let tx_encoding = encoding.unwrap_or(UiTransactionEncoding::Base58);
+            let binary_encoding = tx_encoding.into_binary_encoding().ok_or_else(|| {
+                Error::invalid_params(format!(
+                    "unsupported encoding: {tx_encoding}. Supported encodings: base58, base64"
+                ))
+            })?;
+            let (_wire_transaction, unsanitized_tx) =
+                decode_and_deserialize::<VersionedTransaction>(data, binary_encoding)?;
+
+            let bank = &*meta.get_bank_with_config(RpcContextConfig {
+                commitment,
+                min_context_slot,
+            })?;
+            let transaction =
+                sanitize_transaction(unsanitized_tx, bank, bank.get_reserved_account_keys())?;
+            if sig_verify {
+                verify_transaction(&transaction, &bank.feature_set)?;
+            }
+
+            Ok(())
         }
 
         fn simulate_transaction(

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2627,6 +2627,7 @@ fn get_spl_token_owner_filter(program_id: &Pubkey, filters: &[RpcFilterType]) ->
                 }
             }
             RpcFilterType::TokenAccountState => token_account_state_filter = true,
+            RpcFilterType::ValueCmp(_) => {}
         }
     }
     if data_size_filter == Some(account_packed_len as u64)
@@ -2678,6 +2679,7 @@ fn get_spl_token_mint_filter(program_id: &Pubkey, filters: &[RpcFilterType]) -> 
                 }
             }
             RpcFilterType::TokenAccountState => token_account_state_filter = true,
+            RpcFilterType::ValueCmp(_) => {}
         }
     }
     if data_size_filter == Some(account_packed_len as u64)

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2365,7 +2365,9 @@ impl JsonRpcRequestProcessor {
     ) -> Result<RpcResponse<RpcBlockhash>> {
         let mut bank = self.get_bank_with_config(config.context)?;
         if config.rollback > MAX_PROCESSING_AGE {
-            return Err(Error::invalid_params(format!("rollback exceeds ${MAX_PROCESSING_AGE}")));
+            return Err(Error::invalid_params(format!(
+                "rollback exceeds ${MAX_PROCESSING_AGE}"
+            )));
         }
         if config.rollback > 0 {
             let r_bank_forks = self.bank_forks.read().unwrap();
@@ -3730,10 +3732,13 @@ pub mod rpc_full {
                         let (version, feature_set) = if let Some(version) =
                             cluster_info.get_node_version(contact_info.pubkey())
                         {
-                            (Some(version.to_string()), Some(version.feature_set))
+                            (Some(format!("{:?}", version)), Some(version.feature_set))
+                            // version will be displayed:
+                            // solana 2.2.15 (src:7aff93a2; feat:798020478, client:Agave)
                         } else {
                             (None, None)
                         };
+
                         Some(RpcContactInfo {
                             pubkey: contact_info.pubkey().to_string(),
                             gossip: contact_info.gossip(),

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3849,6 +3849,7 @@ pub mod rpc_full {
             debug!("send_transaction rpc request received");
             let RpcSendTransactionConfig {
                 skip_preflight,
+                skip_sanitize,
                 preflight_commitment,
                 encoding,
                 max_retries,
@@ -3873,30 +3874,49 @@ pub mod rpc_full {
                 min_context_slot,
             })?;
 
-            let transaction = sanitize_transaction(
-                unsanitized_tx,
-                preflight_bank,
-                preflight_bank.get_reserved_account_keys(),
-            )?;
-            let signature = *transaction.signature();
+            let recent_blockhash = *unsanitized_tx.message.recent_blockhash();
+            let (signature, sanitized_tx) = if skip_preflight && skip_sanitize {
+                unsanitized_tx.sanitize().map_err(|_err| {
+                    Error::invalid_params(format!(
+                        "invalid transaction: {}",
+                        TransactionError::SanitizeFailure
+                    ))
+                })?;
+                (unsanitized_tx.signatures[0], None)
+            } else {
+                let tx = sanitize_transaction(
+                    unsanitized_tx,
+                    preflight_bank,
+                    preflight_bank.get_reserved_account_keys(),
+                )?;
+                (*tx.signature(), Some(tx))
+            };
 
             let mut last_valid_block_height = preflight_bank
-                .get_blockhash_last_valid_block_height(transaction.message().recent_blockhash())
+                .get_blockhash_last_valid_block_height(&recent_blockhash)
                 .unwrap_or(0);
 
-            let durable_nonce_info = transaction
-                .get_durable_nonce()
-                .map(|&pubkey| (pubkey, *transaction.message().recent_blockhash()));
-            if durable_nonce_info.is_some() || (skip_preflight && last_valid_block_height == 0) {
-                // While it uses a defined constant, this last_valid_block_height value is chosen arbitrarily.
-                // It provides a fallback timeout for durable-nonce transaction retries in case of
-                // malicious packing of the retry queue. Durable-nonce transactions are otherwise
-                // retried until the nonce is advanced.
-                last_valid_block_height = preflight_bank.block_height() + MAX_PROCESSING_AGE as u64;
+            let mut durable_nonce_info = None;
+            if let Some(sanitized_tx) = &sanitized_tx {
+                durable_nonce_info = sanitized_tx
+                    .get_durable_nonce()
+                    .map(|&pubkey| (pubkey, recent_blockhash));
+                if durable_nonce_info.is_some() || (skip_preflight && last_valid_block_height == 0)
+                {
+                    // While it uses a defined constant, this last_valid_block_height value is chosen arbitrarily.
+                    // It provides a fallback timeout for durable-nonce transaction retries in case of
+                    // malicious packing of the retry queue. Durable-nonce transactions are otherwise
+                    // retried until the nonce is advanced.
+                    last_valid_block_height =
+                        preflight_bank.block_height() + MAX_PROCESSING_AGE as u64;
+                }
             }
 
             if !skip_preflight {
-                verify_transaction(&transaction, &preflight_bank.feature_set)?;
+                let Some(sanitized_tx) = sanitized_tx else {
+                    return Err(Error::invalid_params("sanitized transaction should exists"));
+                };
+                verify_transaction(&sanitized_tx, &preflight_bank.feature_set)?;
 
                 if !meta.config.skip_preflight_health_check {
                     match meta.health.check() {
@@ -3925,7 +3945,7 @@ pub mod rpc_full {
                     units_consumed,
                     return_data,
                     inner_instructions: _, // Always `None` due to `enable_cpi_recording = false`
-                } = preflight_bank.simulate_transaction(&transaction, false)
+                } = preflight_bank.simulate_transaction(&sanitized_tx, false)
                 {
                     match err {
                         TransactionError::BlockhashNotFound => {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2359,8 +2359,28 @@ impl JsonRpcRequestProcessor {
         }
     }
 
-    fn get_latest_blockhash(&self, config: RpcContextConfig) -> Result<RpcResponse<RpcBlockhash>> {
-        let bank = self.get_bank_with_config(config)?;
+    fn get_latest_blockhash(
+        &self,
+        config: RpcLatestBlockhashConfig,
+    ) -> Result<RpcResponse<RpcBlockhash>> {
+        let mut bank = self.get_bank_with_config(config.context)?;
+        if config.rollback > MAX_PROCESSING_AGE {
+            return Err(Error::invalid_params(format!("rollback exceeds ${MAX_PROCESSING_AGE}")));
+        }
+        if config.rollback > 0 {
+            let r_bank_forks = self.bank_forks.read().unwrap();
+            for _ in 0..config.rollback {
+                bank = match r_bank_forks.get(bank.parent_slot()).or_else(|| {
+                    r_bank_forks
+                        .banks_frozen
+                        .get(&bank.parent_slot())
+                        .map(Clone::clone)
+                }) {
+                    Some(bank) => bank,
+                    None => return Err(Error::invalid_params("failed to rollback block")),
+                };
+            }
+        }
         let blockhash = bank.last_blockhash();
         let last_valid_block_height = bank
             .get_blockhash_last_valid_block_height(&blockhash)
@@ -3624,7 +3644,7 @@ pub mod rpc_full {
         fn get_latest_blockhash(
             &self,
             meta: Self::Metadata,
-            config: Option<RpcContextConfig>,
+            config: Option<RpcLatestBlockhashConfig>,
         ) -> Result<RpcResponse<RpcBlockhash>>;
 
         #[rpc(meta, name = "isBlockhashValid")]
@@ -4293,7 +4313,7 @@ pub mod rpc_full {
         fn get_latest_blockhash(
             &self,
             meta: Self::Metadata,
-            config: Option<RpcContextConfig>,
+            config: Option<RpcLatestBlockhashConfig>,
         ) -> Result<RpcResponse<RpcBlockhash>> {
             debug!("get_latest_blockhash rpc request received");
             meta.get_latest_blockhash(config.unwrap_or_default())

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -15,12 +15,12 @@ use {
     solana_measure::measure::Measure,
     solana_program_runtime::loaded_programs::{BlockRelation, ForkGraph},
     solana_sdk::{
-        clock::{BankId, Slot},
+        clock::{BankId, Slot, MAX_PROCESSING_AGE},
         hash::Hash,
     },
     solana_unified_scheduler_logic::SchedulingMode,
     std::{
-        collections::{hash_map::Entry, HashMap, HashSet},
+        collections::{hash_map::Entry, BTreeMap, HashMap, HashSet},
         ops::Index,
         sync::{
             atomic::{AtomicBool, AtomicU64, Ordering},
@@ -74,6 +74,7 @@ struct SetRootTimings {
 
 pub struct BankForks {
     banks: HashMap<Slot, BankWithScheduler>,
+    pub banks_frozen: BTreeMap<Slot, Arc<Bank>>,
     descendants: HashMap<Slot, HashSet<Slot>>,
     root: Arc<AtomicSlot>,
 
@@ -129,6 +130,7 @@ impl BankForks {
         let bank_forks = Arc::new(RwLock::new(Self {
             root: Arc::new(AtomicSlot::new(root_slot)),
             banks,
+            banks_frozen: Default::default(),
             descendants,
             snapshot_config: None,
             accounts_hash_interval_slots: u64::MAX,
@@ -268,6 +270,13 @@ impl BankForks {
 
     pub fn remove(&mut self, slot: Slot) -> Option<BankWithScheduler> {
         let bank = self.banks.remove(&slot)?;
+        if bank.is_frozen() {
+            self.banks_frozen
+                .insert(bank.slot(), bank.clone_without_scheduler());
+            while self.banks_frozen.len() > MAX_PROCESSING_AGE {
+                self.banks_frozen.pop_first();
+            }
+        }
         for parent in bank.proper_ancestors() {
             let Entry::Occupied(mut entry) = self.descendants.entry(parent) else {
                 panic!("this should not happen!");

--- a/runtime/src/prioritization_fee.rs
+++ b/runtime/src/prioritization_fee.rs
@@ -136,13 +136,13 @@ pub enum PrioritizationFeeError {
 /// block; and the minimum fee for each writable account in all transactions in this block. The only relevant
 /// write account minimum fees are those greater than the block minimum transaction fee, because the minimum fee needed to land
 /// a transaction is determined by Max( min_transaction_fee, min_writable_account_fees(key), ...)
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct PrioritizationFee {
-    // The minimum prioritization fee of transactions that landed in this block.
-    min_transaction_fee: u64,
+    // Prioritization fee of transactions that landed in this block.
+    transaction_fees: Vec<u64>,
 
-    // The minimum prioritization fee of each writable account in transactions in this block.
-    min_writable_account_fees: HashMap<Pubkey, u64>,
+    // Prioritization fee of each writable account in transactions in this block.
+    writable_account_fees: HashMap<Pubkey, Vec<u64>>,
 
     // Default to `false`, set to `true` when a block is completed, therefore the minimum fees recorded
     // are finalized, and can be made available for use (e.g., RPC query)
@@ -152,33 +152,18 @@ pub struct PrioritizationFee {
     metrics: PrioritizationFeeMetrics,
 }
 
-impl Default for PrioritizationFee {
-    fn default() -> Self {
-        PrioritizationFee {
-            min_transaction_fee: u64::MAX,
-            min_writable_account_fees: HashMap::new(),
-            is_finalized: false,
-            metrics: PrioritizationFeeMetrics::default(),
-        }
-    }
-}
-
 impl PrioritizationFee {
     /// Update self for minimum transaction fee in the block and minimum fee for each writable account.
     pub fn update(&mut self, transaction_fee: u64, writable_accounts: Vec<Pubkey>) {
         let (_, update_us) = measure_us!({
             if !self.is_finalized {
-                if transaction_fee < self.min_transaction_fee {
-                    self.min_transaction_fee = transaction_fee;
-                }
+                self.transaction_fees.push(transaction_fee);
 
                 for write_account in writable_accounts {
-                    self.min_writable_account_fees
+                    self.writable_account_fees
                         .entry(write_account)
-                        .and_modify(|write_lock_fee| {
-                            *write_lock_fee = std::cmp::min(*write_lock_fee, transaction_fee)
-                        })
-                        .or_insert(transaction_fee);
+                        .or_default()
+                        .push(transaction_fee);
                 }
 
                 self.metrics
@@ -193,38 +178,54 @@ impl PrioritizationFee {
         self.metrics.accumulate_total_update_elapsed_us(update_us);
     }
 
-    /// Accounts that have minimum fees lesser or equal to the minimum fee in the block are redundant, they are
-    /// removed to reduce memory footprint when mark_block_completed() is called.
-    fn prune_irrelevant_writable_accounts(&mut self) {
-        self.metrics.total_writable_accounts_count = self.get_writable_accounts_count() as u64;
-        self.min_writable_account_fees
-            .retain(|_, account_fee| account_fee > &mut self.min_transaction_fee);
-        self.metrics.relevant_writable_accounts_count = self.get_writable_accounts_count() as u64;
-    }
-
     pub fn mark_block_completed(&mut self) -> Result<(), PrioritizationFeeError> {
         if self.is_finalized {
             return Err(PrioritizationFeeError::BlockIsAlreadyFinalized);
         }
-        self.prune_irrelevant_writable_accounts();
         self.is_finalized = true;
+
+        self.transaction_fees.sort();
+        for fees in self.writable_account_fees.values_mut() {
+            fees.sort()
+        }
+
+        self.metrics.total_writable_accounts_count = self.get_writable_accounts_count() as u64;
+        self.metrics.relevant_writable_accounts_count = self.get_writable_accounts_count() as u64;
+
         Ok(())
     }
 
     pub fn get_min_transaction_fee(&self) -> Option<u64> {
-        (self.min_transaction_fee != u64::MAX).then_some(self.min_transaction_fee)
+        self.transaction_fees.first().copied()
     }
 
-    pub fn get_writable_account_fee(&self, key: &Pubkey) -> Option<u64> {
-        self.min_writable_account_fees.get(key).copied()
+    fn get_percentile(fees: &[u64], percentile: u16) -> Option<u64> {
+        let index = (percentile as usize).min(9_999) * fees.len() / 10_000;
+        fees.get(index).copied()
     }
 
-    pub fn get_writable_account_fees(&self) -> impl Iterator<Item = (&Pubkey, &u64)> {
-        self.min_writable_account_fees.iter()
+    pub fn get_transaction_fee(&self, percentile: u16) -> Option<u64> {
+        Self::get_percentile(&self.transaction_fees, percentile)
+    }
+
+    pub fn get_min_writable_account_fee(&self, key: &Pubkey) -> Option<u64> {
+        self.writable_account_fees
+            .get(key)
+            .and_then(|fees| fees.first().copied())
+    }
+
+    pub fn get_writable_account_fee(&self, key: &Pubkey, percentile: u16) -> Option<u64> {
+        self.writable_account_fees
+            .get(key)
+            .and_then(|fees| Self::get_percentile(fees, percentile))
+    }
+
+    pub fn get_writable_account_fees(&self) -> impl Iterator<Item = (&Pubkey, &Vec<u64>)> {
+        self.writable_account_fees.iter()
     }
 
     pub fn get_writable_accounts_count(&self) -> usize {
-        self.min_writable_account_fees.len()
+        self.writable_account_fees.len()
     }
 
     pub fn is_finalized(&self) -> bool {
@@ -236,20 +237,28 @@ impl PrioritizationFee {
 
         // report this slot's min_transaction_fee and top 10 min_writable_account_fees
         let min_transaction_fee = self.get_min_transaction_fee().unwrap_or(0);
-        let mut accounts_fees: Vec<_> = self.get_writable_account_fees().collect();
-        accounts_fees.sort_by(|lh, rh| rh.1.cmp(lh.1));
         datapoint_info!(
             "block_min_prioritization_fee",
             ("slot", slot as i64, i64),
             ("entity", "block", String),
             ("min_prioritization_fee", min_transaction_fee as i64, i64),
         );
-        for (account_key, fee) in accounts_fees.iter().take(10) {
+
+        let mut accounts_fees: Vec<(&Pubkey, u64)> = self
+            .get_writable_account_fees()
+            .filter_map(|(account, fees)| {
+                fees.first()
+                    .copied()
+                    .map(|min_account_fee| (account, min_transaction_fee.min(min_account_fee)))
+            })
+            .collect();
+        accounts_fees.sort_by(|lh, rh| rh.1.cmp(&lh.1));
+        for (account_key, fee) in accounts_fees.into_iter().take(10) {
             datapoint_trace!(
                 "block_min_prioritization_fee",
                 ("slot", slot as i64, i64),
                 ("entity", account_key.to_string(), String),
-                ("min_prioritization_fee", **fee as i64, i64),
+                ("min_prioritization_fee", fee as i64, i64),
             );
         }
     }
@@ -275,22 +284,26 @@ mod tests {
         // [5,   a, b             ]  -->  [5,     5,         5,         nil      ]
         {
             prioritization_fee.update(5, vec![write_account_a, write_account_b]);
+            assert!(prioritization_fee.mark_block_completed().is_ok());
+
             assert_eq!(5, prioritization_fee.get_min_transaction_fee().unwrap());
             assert_eq!(
                 5,
                 prioritization_fee
-                    .get_writable_account_fee(&write_account_a)
+                    .get_min_writable_account_fee(&write_account_a)
                     .unwrap()
             );
             assert_eq!(
                 5,
                 prioritization_fee
-                    .get_writable_account_fee(&write_account_b)
+                    .get_min_writable_account_fee(&write_account_b)
                     .unwrap()
             );
             assert!(prioritization_fee
-                .get_writable_account_fee(&write_account_c)
+                .get_min_writable_account_fee(&write_account_c)
                 .is_none());
+
+            prioritization_fee.is_finalized = false;
         }
 
         // Assert for second transaction:
@@ -299,25 +312,29 @@ mod tests {
         // [9,      b, c          ]  -->  [5,     5,         5,         9        ]
         {
             prioritization_fee.update(9, vec![write_account_b, write_account_c]);
+            assert!(prioritization_fee.mark_block_completed().is_ok());
+
             assert_eq!(5, prioritization_fee.get_min_transaction_fee().unwrap());
             assert_eq!(
                 5,
                 prioritization_fee
-                    .get_writable_account_fee(&write_account_a)
+                    .get_min_writable_account_fee(&write_account_a)
                     .unwrap()
             );
             assert_eq!(
                 5,
                 prioritization_fee
-                    .get_writable_account_fee(&write_account_b)
+                    .get_min_writable_account_fee(&write_account_b)
                     .unwrap()
             );
             assert_eq!(
                 9,
                 prioritization_fee
-                    .get_writable_account_fee(&write_account_c)
+                    .get_min_writable_account_fee(&write_account_c)
                     .unwrap()
             );
+
+            prioritization_fee.is_finalized = false;
         }
 
         // Assert for third transaction:
@@ -326,44 +343,56 @@ mod tests {
         // [2,   a,    c          ]  -->  [2,     2,         5,         2        ]
         {
             prioritization_fee.update(2, vec![write_account_a, write_account_c]);
+            assert!(prioritization_fee.mark_block_completed().is_ok());
+
             assert_eq!(2, prioritization_fee.get_min_transaction_fee().unwrap());
             assert_eq!(
                 2,
                 prioritization_fee
-                    .get_writable_account_fee(&write_account_a)
+                    .get_min_writable_account_fee(&write_account_a)
                     .unwrap()
             );
             assert_eq!(
                 5,
                 prioritization_fee
-                    .get_writable_account_fee(&write_account_b)
+                    .get_min_writable_account_fee(&write_account_b)
                     .unwrap()
             );
             assert_eq!(
                 2,
                 prioritization_fee
-                    .get_writable_account_fee(&write_account_c)
+                    .get_min_writable_account_fee(&write_account_c)
                     .unwrap()
             );
+
+            prioritization_fee.is_finalized = false;
         }
 
-        // assert after prune, account a and c should be removed from cache to save space
+        // assert after sort
         {
-            prioritization_fee.prune_irrelevant_writable_accounts();
-            assert_eq!(1, prioritization_fee.min_writable_account_fees.len());
+            prioritization_fee.update(2, vec![write_account_a, write_account_c]);
+            assert!(prioritization_fee.mark_block_completed().is_ok());
+
             assert_eq!(2, prioritization_fee.get_min_transaction_fee().unwrap());
-            assert!(prioritization_fee
-                .get_writable_account_fee(&write_account_a)
-                .is_none());
+            assert_eq!(3, prioritization_fee.writable_account_fees.len());
+            assert_eq!(
+                2,
+                prioritization_fee
+                    .get_min_writable_account_fee(&write_account_a)
+                    .unwrap()
+            );
             assert_eq!(
                 5,
                 prioritization_fee
-                    .get_writable_account_fee(&write_account_b)
+                    .get_min_writable_account_fee(&write_account_b)
                     .unwrap()
             );
-            assert!(prioritization_fee
-                .get_writable_account_fee(&write_account_c)
-                .is_none());
+            assert_eq!(
+                2,
+                prioritization_fee
+                    .get_min_writable_account_fee(&write_account_c)
+                    .unwrap()
+            );
         }
     }
 

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -420,7 +420,32 @@ impl PrioritizationFeeCache {
                     .unwrap_or_default();
                 for account_key in account_keys {
                     if let Some(account_fee) =
-                        slot_prioritization_fee.get_writable_account_fee(account_key)
+                        slot_prioritization_fee.get_min_writable_account_fee(account_key)
+                    {
+                        fee = std::cmp::max(fee, account_fee);
+                    }
+                }
+                (*slot, fee)
+            })
+            .collect()
+    }
+
+    pub fn get_prioritization_fees2(
+        &self,
+        account_keys: &[Pubkey],
+        percentile: u16,
+    ) -> Vec<(Slot, u64)> {
+        self.cache
+            .read()
+            .unwrap()
+            .iter()
+            .map(|(slot, slot_prioritization_fee)| {
+                let mut fee = slot_prioritization_fee
+                    .get_transaction_fee(percentile)
+                    .unwrap_or_default();
+                for account_key in account_keys {
+                    if let Some(account_fee) =
+                        slot_prioritization_fee.get_writable_account_fee(account_key, percentile)
                     {
                         fee = std::cmp::max(fee, account_fee);
                     }
@@ -554,9 +579,18 @@ mod tests {
             let lock = prioritization_fee_cache.cache.read().unwrap();
             let fee = lock.get(&slot).unwrap();
             assert_eq!(2, fee.get_min_transaction_fee().unwrap());
-            assert!(fee.get_writable_account_fee(&write_account_a).is_none());
-            assert_eq!(5, fee.get_writable_account_fee(&write_account_b).unwrap());
-            assert!(fee.get_writable_account_fee(&write_account_c).is_none());
+            assert_eq!(
+                2,
+                fee.get_min_writable_account_fee(&write_account_a).unwrap()
+            );
+            assert_eq!(
+                5,
+                fee.get_min_writable_account_fee(&write_account_b).unwrap()
+            );
+            assert_eq!(
+                2,
+                fee.get_min_writable_account_fee(&write_account_c).unwrap()
+            );
         }
     }
 

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -9,6 +9,7 @@ use {
     backoff::{future::retry, Error as BackoffError, ExponentialBackoff},
     log::*,
     std::{
+        collections::HashMap,
         str::FromStr,
         time::{Duration, Instant},
     },
@@ -781,6 +782,31 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
             .collect())
     }
 
+    pub async fn get_bincode_cells2<T>(
+        &mut self,
+        table: &str,
+        keys: &[RowKey],
+    ) -> Result<(HashMap<RowKey, Result<T>>, usize)>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let mut size = 0;
+        let rows = self
+            .get_multi_row_data(table, keys)
+            .await?
+            .into_iter()
+            .map(|(key, row_data)| {
+                size += row_data.len();
+                let key_str = key.to_string();
+                (
+                    key,
+                    deserialize_bincode_cell_data(&row_data, table, key_str),
+                )
+            })
+            .collect();
+        Ok((rows, size))
+    }
+
     pub async fn get_protobuf_cell<P>(&mut self, table: &str, key: RowKey) -> Result<P>
     where
         P: prost::Message + Default,
@@ -823,6 +849,33 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
                 (
                     key,
                     deserialize_protobuf_or_bincode_cell_data(&row_data, table, key_str).unwrap(),
+                )
+            }))
+    }
+
+    pub async fn get_protobuf_or_bincode_cells2<'a, B, P>(
+        &mut self,
+        table: &'a str,
+        row_keys: impl IntoIterator<Item = RowKey>,
+    ) -> Result<impl Iterator<Item = (RowKey, CellData<B, P>, usize)> + 'a>
+    where
+        B: serde::de::DeserializeOwned,
+        P: prost::Message + Default,
+    {
+        Ok(self
+            .get_multi_row_data(
+                table,
+                row_keys.into_iter().collect::<Vec<RowKey>>().as_slice(),
+            )
+            .await?
+            .into_iter()
+            .map(|(key, row_data)| {
+                let size = row_data.iter().fold(0, |acc, row| acc + row.1.len());
+                let key_str = key.to_string();
+                (
+                    key,
+                    deserialize_protobuf_or_bincode_cell_data(&row_data, table, key_str).unwrap(),
+                    size,
                 )
             }))
     }

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -79,6 +79,16 @@ impl std::convert::From<std::io::Error> for Error {
     }
 }
 
+impl Error {
+    pub fn is_rpc_unauthenticated(&self) -> bool {
+        if let Error::BigTableError(bigtable::Error::Rpc(status)) = self {
+            status.code() == tonic::Code::Unauthenticated
+        } else {
+            false
+        }
+    }
+}
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 // Convert a slot to its bucket representation whereby lower slots are always lexically ordered
@@ -761,6 +771,170 @@ impl LedgerStorage {
                 }
             }
         }
+    }
+
+    // Fetches and gets a vector of confirmed blocks via a multirow fetch
+    pub async fn get_confirmed_blocks_with_data2<'a>(
+        &self,
+        slots: &'a [Slot],
+    ) -> Result<impl Iterator<Item = (Option<(Slot, ConfirmedBlock)>, usize)> + 'a> {
+        debug!(
+            "LedgerStorage::get_confirmed_blocks_with_data request received: {:?}",
+            slots
+        );
+        inc_new_counter_debug!("storage-bigtable-query", 1);
+        let mut bigtable = self.connection.client();
+        let row_keys = slots.iter().copied().map(slot_to_blocks_key);
+        Ok(bigtable
+            .get_protobuf_or_bincode_cells2("blocks", row_keys)
+            .await?
+            .map(
+                |(row_key, block_cell_data, size): (
+                    RowKey,
+                    bigtable::CellData<StoredConfirmedBlock, generated::ConfirmedBlock>,
+                    usize,
+                )| {
+                    let block = match block_cell_data {
+                        bigtable::CellData::Bincode(block) => block.into(),
+                        bigtable::CellData::Protobuf(block) => match block.try_into() {
+                            Ok(block) => block,
+                            Err(_) => return (None, size),
+                        },
+                    };
+                    (Some((key_to_slot(&row_key).unwrap(), block)), size)
+                },
+            ))
+    }
+
+    /// Fetch blocks and transactions
+    pub async fn get_confirmed_blocks_transactions(
+        &self,
+        blocks: &[Slot],
+        transactions: &[String],
+        transactions_status: &[String],
+    ) -> Result<(
+        Vec<(Slot, ConfirmedBlock)>,
+        Vec<ConfirmedTransactionWithStatusMeta>,
+        HashMap<String, TransactionStatus>,
+        usize,
+    )> {
+        let mut bigtable = self.connection.client();
+
+        let mut blocks_resp = Vec::with_capacity(blocks.len());
+        let mut transactions_resp = Vec::with_capacity(transactions.len());
+        let mut transactions_status_resp = HashMap::new();
+        let mut size = 0;
+
+        // Collect slots for request
+        let mut blocks_map: HashMap<Slot, Vec<(u32, String)>> = HashMap::new();
+        for block in blocks {
+            blocks_map.entry(*block).or_default();
+        }
+
+        // Fetch transactions info and collect slots
+        if !transactions.is_empty() || !transactions_status.is_empty() {
+            let mut keys = Vec::with_capacity(transactions.len() + transactions_status.len());
+            keys.extend(transactions.iter().cloned());
+            keys.extend(transactions_status.iter().cloned());
+
+            let (mut cells, bt_size) = bigtable
+                .get_bincode_cells2::<TransactionInfo>("tx", keys.as_slice())
+                .await?;
+            size += bt_size;
+
+            for signature in transactions_status {
+                if let Some(Ok(info)) = cells.get(signature) {
+                    transactions_status_resp.insert(
+                        signature.clone(),
+                        TransactionStatus {
+                            slot: info.slot,
+                            confirmations: None,
+                            status: match &info.err {
+                                Some(err) => Err(err.clone()),
+                                None => Ok(()),
+                            },
+                            err: info.err.clone(),
+                            confirmation_status: Some(TransactionConfirmationStatus::Finalized),
+                        },
+                    );
+                }
+            }
+            for signature in transactions {
+                if let Some((signature, Ok(TransactionInfo { slot, index, .. }))) =
+                    cells.remove_entry(signature)
+                {
+                    blocks_map.entry(slot).or_default().push((index, signature));
+                }
+            }
+        }
+
+        // Fetch blocks
+        if !blocks_map.is_empty() {
+            let keys = blocks_map.keys().copied().collect::<Vec<_>>();
+            let cells = self.get_confirmed_blocks_with_data2(&keys).await?;
+            for (maybe_slot_block, row_size) in cells {
+                size += row_size;
+                if let Some((slot, block)) = maybe_slot_block {
+                    if let Some(entries) = blocks_map.get(&slot) {
+                        for (index, signature) in entries.iter() {
+                            if let Some(tx_with_meta) = block.transactions.get(*index as usize) {
+                                if tx_with_meta.transaction_signature().to_string() != *signature {
+                                    warn!(
+                                        "Transaction info or confirmed block for {} is corrupt",
+                                        signature
+                                    );
+                                } else {
+                                    transactions_resp.push(ConfirmedTransactionWithStatusMeta {
+                                        slot,
+                                        tx_with_meta: tx_with_meta.clone(),
+                                        block_time: block.block_time,
+                                    });
+                                }
+                            }
+                        }
+                        blocks_resp.push((slot, block));
+                    }
+                }
+            }
+        }
+
+        Ok((
+            blocks_resp,
+            transactions_resp,
+            transactions_status_resp,
+            size,
+        ))
+    }
+
+    /// Fetch TX index for transactions
+    pub async fn get_txindex(
+        &self,
+        transactions: &[String],
+    ) -> Result<(Vec<Option<(Slot, u32)>>, usize)> {
+        let mut bigtable = self.connection.client();
+
+        let mut response = Vec::with_capacity(transactions.len());
+        let mut size = 0;
+
+        // Fetch transactions info and collect slots
+        if transactions.is_empty() {
+            response.resize(transactions.len(), None);
+        } else {
+            let (cells, bt_size) = bigtable
+                .get_bincode_cells2::<TransactionInfo>("tx", transactions)
+                .await?;
+            size += bt_size;
+
+            for signature in transactions {
+                if let Some(Ok(TransactionInfo { slot, index, .. })) = cells.get(signature) {
+                    response.push(Some((*slot, *index)));
+                } else {
+                    response.push(None);
+                }
+            }
+        }
+
+        Ok((response, size))
     }
 
     /// Get confirmed signatures for the provided address, in descending ledger order


### PR DESCRIPTION
#### Problem
We need the Client-ID to use on validators.app

#### Summary of Changes
I made a simple modification where I'm using the Debug version output of Version, because it exposes the Client ID;
```rust
impl fmt::Debug for Version {
    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
        write!(
            f,
            "{}.{}.{} (src:{:08x}; feat:{}, client:{:?})",
            self.major,
            self.minor,
            self.patch,
            self.commit,
            self.feature_set,
            self.client(),
        )
    }
}
```
I didn't wanted to add a new parameter to the client-id because it would change the API for the getClusterNodes, so what you will receive now instead of the version is:
**2.2.15 (src:00000000; feat:798020478, client:Agave)**
instead of
**2.2.15**

It's easy to parse this, if you want to get the version just split based on the "(" and get the first part, then to get the version do the same but for "client:" and get second part.

here's what you going to see (I prettified the json, just to make easy to visualize.)

```bash
leafar@rafael-pc:~$ curl -X POST http://127.0.0.1:8899 \
  -H "Content-Type: application/json" \
  -d '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "getClusterNodes"
  }'
```
RESPONSE:
```json
{
  "jsonrpc": "2.0",
  "result": [
    {
      "featureSet": 798020478,
      "gossip": "127.0.0.1:1024",
      "pubkey": "CEucL8UAsFZur9Ce57F7jM5hr7RVMY1KYwgbL5nQrbFE",
      "pubsub": "127.0.0.1:8900",
      "rpc": "127.0.0.1:8899",
      "serveRepair": "127.0.0.1:1036",
      "shredVersion": 46683,
      "tpu": "127.0.0.1:1027",
      "tpuForwards": "127.0.0.1:1028",
      "tpuForwardsQuic": "127.0.0.1:1034",
      "tpuQuic": "127.0.0.1:1033",
      "tpuVote": "127.0.0.1:1029",
      "tvu": "127.0.0.1:1025",
      "version": "2.2.15 (src:00000000; feat:798020478, client:Agave)"
    }
  ],
  "id": 1
}
```